### PR TITLE
Fixbug: invalid parse ipv6 Protocal:/[::]:port

### DIFF
--- a/GatewayWorker/Gateway.php
+++ b/GatewayWorker/Gateway.php
@@ -229,7 +229,7 @@ class Gateway extends Worker
     public function __construct($socket_name, $context_option = array())
     {
         parent::__construct($socket_name, $context_option);
-        list(, , $this->_gatewayPort) = explode(':', $socket_name);
+		$this->_gatewayPort = substr(strrchr($socket_name,':'),1);
         $this->router = array("\\GatewayWorker\\Gateway", 'routerBind');
 
         $backrace                = debug_backtrace();


### PR DESCRIPTION
解析类似 new Gateway('text://[::]:1234')　失败，得到的端口是０．这个提交修正了此错误