### PR TITLE
fix 循环链接多个注册地址造成的资源浪费和bug

### DIFF
--- a/src/Lib/Gateway.php
+++ b/src/Lib/Gateway.php
@@ -1315,8 +1315,8 @@ class Gateway
         if(empty($addresses_cache) || $time_now - $last_update > $expiration_time) {
             foreach ($register_addresses as $register_address) {
                 $client = stream_socket_client('tcp://' . $register_address, $errno, $errmsg, static::$connectTimeout);
-                if (!$client) {
-                    continue;
+                if ($client) {
+                    break;
                 }
             }
             if (!$client) {


### PR DESCRIPTION
循环链接多个注册地址时没必要全部注册地址链接一遍，造成资源浪费；
因为是后面$client变量覆盖前面$client，如果最后一个注册器链接失败会导致报错。