### PR TITLE
用于解决 gatewayWorker In docker innerWorkerListen

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -50,6 +50,21 @@ class Gateway extends Worker
     public $lanIp = '127.0.0.1';
 
     /**
+     * 如果宿主机为192.168.1.2 , gatewayworker in  docker container (172.25.0.2)
+     * 此时 lanIp=192.68.1.2 GatewayClientSDK 能连上，但是$this->_innerTcpWorker stream_socket_server(): Unable to connect to tcp://192.168.1.2:2901 (Address not available) in
+     * 此时 lanIp=172.25.0.2 GatewayClientSDK stream_socket_server(): Unable to connect to tcp://172.25.0.2:2901 (Address not available) ， $this->_innerTcpWorker 正常监听
+     *
+     * solution:
+     * $gateway->lanIp=192.168.1.2 ;
+     * $gateway->innerTcpWorkerListen=172.25.0.2; // || 0.0.0.0
+     *
+     * GatewayClientSDK connect  192.168.1.2:lanPort
+     * $this->_innerTcpWorker listen  $gateway->lanIp:lanPort
+     *
+     */
+    public $innerTcpWorkerListen='';
+	
+    /**
      * 本机端口
      *
      * @var string
@@ -507,6 +522,12 @@ class Gateway extends Worker
 
          //如为公网IP监听，直接换成0.0.0.0 ，否则用内网IP
         $listen_ip=filter_var($this->lanIp,FILTER_VALIDATE_IP,FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE)?'0.0.0.0':$this->lanIp;
+	    
+	//Use scenario to see line 64
+        if($this->innerTcpWorkerListen!='' ){
+            $listen_ip=$this->innerTcpWorkerListen;
+        }
+
         // 初始化 gateway 内部的监听，用于监听 worker 的连接已经连接上发来的数据
         $this->_innerTcpWorker = new Worker("GatewayProtocol://{$listen_ip}:{$this->lanPort}");
         $this->_innerTcpWorker->reusePort = false;

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -59,7 +59,7 @@ class Gateway extends Worker
      * $gateway->innerTcpWorkerListen=172.25.0.2; // || 0.0.0.0
      *
      * GatewayClientSDK connect  192.168.1.2:lanPort
-     * $this->_innerTcpWorker listen  $gateway->lanIp:lanPort
+     * $this->_innerTcpWorker listen  $gateway->innerTcpWorkerListen:lanPort
      *
      */
     public $innerTcpWorkerListen='';


### PR DESCRIPTION
在docker 部署上遇到了一问题，或者说 是   LanIP 在 register注册公开地址与 本地 gateway 2900的api地址的 解耦


![image](https://user-images.githubusercontent.com/56504552/211971783-79595e7b-6363-4e9a-bdea-9b096986ac97.png)
