### PR TITLE
Optimize: k8s健康检测情况下，产生大量auth timeout

### DIFF
--- a/src/Register.php
+++ b/src/Register.php
@@ -160,6 +160,8 @@ class Register extends Worker
      */
     public function onClose($connection)
     {
+        // 删除定时器
+        Timer::del($connection->timeout_timerid);
         if (isset($this->_gatewayConnections[$connection->id])) {
             unset($this->_gatewayConnections[$connection->id]);
             $this->broadcastAddresses();


### PR DESCRIPTION
```
livenessProbe:
          tcpSocket:
            port: 1215
          initialDelaySeconds: 10
          periodSeconds: 3
        readinessProbe:
          tcpSocket:
            port: 1215
          initialDelaySeconds: 10
          periodSeconds: 3
```


配置了健康检测，k8s会每间隔几秒就探测1215端口是否可用，close的时候应该清空Timer