### PR TITLE
F 修复Gateway内部IP使用域名时的问题

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -323,7 +323,7 @@ class Gateway extends Worker
         $connection->id = self::generateConnectionId();
         // 保存该连接的内部通讯的数据包报头，避免每次重新初始化
         $connection->gatewayHeader = array(
-            'local_ip'      => ip2long($this->lanIp),
+            'local_ip'      => ip2long(gethostbyname($this->lanIp)),
             'local_port'    => $this->lanPort,
             'client_ip'     => ip2long($connection->getRemoteIp()),
             'client_port'   => $connection->getRemotePort(),


### PR DESCRIPTION
ip2long 不能直接处理域名，会导致 client_id 前面的一部分为0000