### PR TITLE
增加轮询负载均衡

### DIFF
--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -34,7 +34,28 @@ use GatewayWorker\Protocols\GatewayProtocol;
  */
 class Gateway extends Worker
 {
-    
+
+    /**
+     * 随机负载均衡
+     *
+     *@var string
+     */
+    const ROUTER_RANDOM = 'router_random';
+
+    /**
+     * 轮询负载均衡
+     *
+     * @var string
+     */
+    const ROUTER_ROUND_ROBIN = 'router_round_robin';
+
+    /**
+     * 默认负载均衡模式轮询
+     *
+     * @var  string $selectLoadBalancingMode
+     */
+    public static $selectLoadBalancingMode = self::ROUTER_ROUND_ROBIN;
+
     /**
      * 本机 IP
      *  单机部署默认 127.0.0.1，如果是分布式部署，需要设置成本机 IP
@@ -149,6 +170,14 @@ class Gateway extends Worker
      * @var callable|null
      */
     public $onBusinessWorkerClose = null;
+
+    /**
+     * 轮询负载均衡记录
+     * [ ip+businessworker key => 连接记录, ip+businessworker key => 连接记录, .... ]
+     *
+     * @var array
+     */
+    protected static $roundRobinRecord = array();
 
     /**
      * 保存客户端的所有 connection 对象
@@ -440,17 +469,58 @@ class Gateway extends Worker
     }
 
     /**
-     * 随机路由，返回 worker connection 对象
+     * 随机路由，返回 worker connection 标识
      *
      * @param array         $worker_connections
-     * @param TcpConnection $client_connection
-     * @param int           $cmd
-     * @param mixed         $buffer
-     * @return TcpConnection
+     * @return string
      */
-    public static function routerRand($worker_connections, $client_connection, $cmd, $buffer)
+    public static function routerRand(array $worker_connections) : string
     {
-        return $worker_connections[array_rand($worker_connections)];
+        return array_rand($worker_connections);
+    }
+
+    /**
+     * 轮询路由，返回 worker connection 标识
+     * 新上线服务器由于客户端连接数过低，会先分配给新服务器
+     *
+     * @throws  \Exception
+     * @param array         $roundRobinRecord
+     * @return string
+     */
+    protected static function routerRoundRobin(array $roundRobinRecord) : string
+    {
+        if (empty($roundRobinRecord))
+        {
+           throw new \Exception("Round-robin record is empty.");
+        }
+
+        // min($roundRobinRecord) 返回连接数最少businessWorker 连接标识
+        return array_search(min($roundRobinRecord), $roundRobinRecord, true);
+    }
+
+    /**
+     * @param array $roundRobinRecord
+     * @param array $worker_connections
+     * @param string $selectLoadBalancingMode
+     * @return string
+     * @throws \Exception
+     */
+    protected static function businessWorkerAddress(array $roundRobinRecord, array $worker_connections, string $selectLoadBalancingMode)
+    {
+        switch ($selectLoadBalancingMode)
+        {
+            case static::ROUTER_ROUND_ROBIN:
+                // 选择连接最少的businessWorker 服务器
+                $businessWorkerAddress = static::routerRoundRobin($roundRobinRecord);
+                // 增加轮询表记录
+                static::$roundRobinRecord[$businessWorkerAddress]++;
+                return $businessWorkerAddress;
+            case static::ROUTER_RANDOM:
+                // 随机轮询
+                return static::routerRand($worker_connections);
+            default:
+                throw new \Exception("This type of load balancing mode is not supported.");
+        }
     }
 
     /**
@@ -461,11 +531,12 @@ class Gateway extends Worker
      * @param int           $cmd
      * @param mixed         $buffer
      * @return TcpConnection
+     * @throws \Exception
      */
     public static function routerBind($worker_connections, $client_connection, $cmd, $buffer)
     {
         if (!isset($client_connection->businessworker_address) || !isset($worker_connections[$client_connection->businessworker_address])) {
-            $client_connection->businessworker_address = array_rand($worker_connections);
+            $client_connection->businessworker_address = static::businessWorkerAddress(static::$roundRobinRecord, $worker_connections, static::$selectLoadBalancingMode);
         }
         return $worker_connections[$client_connection->businessworker_address];
     }
@@ -479,6 +550,18 @@ class Gateway extends Worker
     {
         // 尝试通知 worker，触发 Event::onClose
         $this->sendToWorker(GatewayProtocol::CMD_ON_CLOSE, $connection);
+
+        // 轮询记录减少
+        if(static::$selectLoadBalancingMode === static::ROUTER_ROUND_ROBIN &&
+            isset($connection->businessworker_address))
+        {
+            // 轮询记录 >0,减少连接数
+            if((static::$roundRobinRecord[$connection->businessworker_address]) > 0)
+            {
+                static::$roundRobinRecord[$connection->businessworker_address]--;
+            }
+        }
+
         unset($this->_clientConnections[$connection->id]);
         // 清理 uid 数据
         if (!empty($connection->uid)) {
@@ -569,7 +652,7 @@ class Gateway extends Worker
     public function onWorkerConnect($connection)
     {
         $connection->maxSendBufferSize = $this->sendToWorkerBufferSize;
-        $connection->authorized = $this->secretKey ? false : true;
+        $connection->authorized = !$this->secretKey;
     }
 
     /**
@@ -608,6 +691,10 @@ class Gateway extends Worker
 		        $connection->key = $key;
                 $this->_workerConnections[$key] = $connection;
                 $connection->authorized = true;
+                // 轮询负载均衡初始化
+                if(static::$selectLoadBalancingMode === static::ROUTER_ROUND_ROBIN) {
+                    static::$roundRobinRecord[$key] = 0;
+                }
                 if ($this->onBusinessWorkerConnected) {
                     call_user_func($this->onBusinessWorkerConnected, $connection);
                 }
@@ -969,6 +1056,11 @@ class Gateway extends Worker
     public function onWorkerClose($connection)
     {
         if (isset($connection->key)) {
+            // 删除轮询记录
+            if (static::$selectLoadBalancingMode === static::ROUTER_ROUND_ROBIN)
+            {
+                unset(static::$roundRobinRecord[$connection->key]);
+            }
             unset($this->_workerConnections[$connection->key]);
             if ($this->onBusinessWorkerClose) {
                 call_user_func($this->onBusinessWorkerClose, $connection);


### PR DESCRIPTION
### hi，你好

> GatewayWorker 负载均衡模式随机性分配，导致每个worker 服务连接负载不均匀，有的进程连接数比较少，有的连接数比较多。
> 所以扩展了一下轮询负载均衡，Nginx 默认也是轮询负载均衡。


测试代码：
并发连接数 5000，测试负载均衡是否均匀。

增加负载均衡模式两种：随机，轮询（已更改为默认）

// 设置轮询
Gateway::$selectLoadBalancingMode = Gateway::ROUTER_ROUND_ROBIN;

// 设置随机
Gateway::$selectLoadBalancingMode = Gateway::ROUTER_RANDOM;

测试负载均衡结果如下：

随机负载均衡：
{
	"127.0.0.1:ChatBusinessWorker:28": 180,
	"127.0.0.1:ChatBusinessWorker:22": 160,
	"127.0.0.1:ChatBusinessWorker:12": 144,
	"127.0.0.1:ChatBusinessWorker:16": 151,
	"127.0.0.1:ChatBusinessWorker:31": 150,
	"127.0.0.1:ChatBusinessWorker:13": 146,
	"127.0.0.1:ChatBusinessWorker:15": 164,
	"127.0.0.1:ChatBusinessWorker:24": 163,
	"127.0.0.1:ChatBusinessWorker:25": 169,
	"127.0.0.1:ChatBusinessWorker:18": 157,
	"127.0.0.1:ChatBusinessWorker:29": 142,
	"127.0.0.1:ChatBusinessWorker:6": 168,
	"127.0.0.1:ChatBusinessWorker:3": 153,
	"127.0.0.1:ChatBusinessWorker:26": 148,
	"127.0.0.1:ChatBusinessWorker:21": 134,
	"127.0.0.1:ChatBusinessWorker:9": 131,
	"127.0.0.1:ChatBusinessWorker:27": 155,
	"127.0.0.1:ChatBusinessWorker:30": 173,
	"127.0.0.1:ChatBusinessWorker:23": 169,
	"127.0.0.1:ChatBusinessWorker:1": 156,
	"127.0.0.1:ChatBusinessWorker:4": 154,
	"127.0.0.1:ChatBusinessWorker:20": 156,
	"127.0.0.1:ChatBusinessWorker:7": 146,
	"127.0.0.1:ChatBusinessWorker:17": 149,
	"127.0.0.1:ChatBusinessWorker:10": 162,
	"127.0.0.1:ChatBusinessWorker:19": 163,
	"127.0.0.1:ChatBusinessWorker:5": 147,
	"127.0.0.1:ChatBusinessWorker:2": 163,
	"127.0.0.1:ChatBusinessWorker:8": 162,
	"127.0.0.1:ChatBusinessWorker:11": 164,
	"127.0.0.1:ChatBusinessWorker:14": 166,
	"127.0.0.1:ChatBusinessWorker:0": 155
}

// 可见随机的劣势，最小值131，最大值180，分配不均衡导致性能问题。

轮询负载均衡：
{
	"127.0.0.1:ChatBusinessWorker:24": 157,
	"127.0.0.1:ChatBusinessWorker:13": 157,
	"127.0.0.1:ChatBusinessWorker:29": 157,
	"127.0.0.1:ChatBusinessWorker:11": 157,
	"127.0.0.1:ChatBusinessWorker:30": 157,
	"127.0.0.1:ChatBusinessWorker:20": 157,
	"127.0.0.1:ChatBusinessWorker:4": 157,
	"127.0.0.1:ChatBusinessWorker:18": 157,
	"127.0.0.1:ChatBusinessWorker:10": 156,
	"127.0.0.1:ChatBusinessWorker:0": 156,
	"127.0.0.1:ChatBusinessWorker:1": 156,
	"127.0.0.1:ChatBusinessWorker:28": 156,
	"127.0.0.1:ChatBusinessWorker:21": 156,
	"127.0.0.1:ChatBusinessWorker:2": 156,
	"127.0.0.1:ChatBusinessWorker:7": 156,
	"127.0.0.1:ChatBusinessWorker:3": 156,
	"127.0.0.1:ChatBusinessWorker:14": 156,
	"127.0.0.1:ChatBusinessWorker:19": 156,
	"127.0.0.1:ChatBusinessWorker:17": 156,
	"127.0.0.1:ChatBusinessWorker:26": 156,
	"127.0.0.1:ChatBusinessWorker:6": 156,
	"127.0.0.1:ChatBusinessWorker:22": 156,
	"127.0.0.1:ChatBusinessWorker:9": 156,
	"127.0.0.1:ChatBusinessWorker:15": 156,
	"127.0.0.1:ChatBusinessWorker:27": 156,
	"127.0.0.1:ChatBusinessWorker:16": 156,
	"127.0.0.1:ChatBusinessWorker:25": 156,
	"127.0.0.1:ChatBusinessWorker:5": 156,
	"127.0.0.1:ChatBusinessWorker:8": 156,
	"127.0.0.1:ChatBusinessWorker:12": 156,
	"127.0.0.1:ChatBusinessWorker:23": 156,
	"127.0.0.1:ChatBusinessWorker:31": 156
}

**从结果来看轮询负载均衡能够好分配连接到业务逻辑服务器，不会出现某些业务服务器空闲，有些繁忙。
可自定义选择使用随机，轮询，我已经修改默认为轮询均衡分配连接给BusinessWorker服务器。**

// array_search(min($roundRobinRecord), $roundRobinRecord, true);
**使用最小值就是方便分布式部署新的服务器进程上线空闲，这时候连接上线初始化连接为0，
Gateway根据内部轮询表判断哪台服务器连接数少就分配给谁，这样达到连接数最终均衡的目的。**

